### PR TITLE
storemgmt: Future proof the recognition of keytypes

### DIFF
--- a/cng_provider/keymgmt/cng_keymgmt_functions.h
+++ b/cng_provider/keymgmt/cng_keymgmt_functions.h
@@ -67,6 +67,7 @@ OSSL_FUNC_keymgmt_export_types_ex_fn cng_keymgmt_export_types_ex;
 
 /* Our provider side key object data type */
 typedef struct s_cng_keymgmt_keydata {
+    const char *keytype;        /* key type, mostly used by store */
     NCRYPT_KEY_HANDLE windows_key_handle;
 } T_CNG_KEYMGMT_KEYDATA;
 


### PR DESCRIPTION
This replaces `key_is_rsa()` with `assign_key_data()`, allowing it to add
whatever data is needed to the keymgmt data structure, while retaining
the return values that `key_is_rsa()` did.

The keymgmt data structure is extended with the keytype, a constant string
that doesn't need any extra management.

With this modification, `load_another_private_key()` should be able to
process any key that this provider supports, given a couple of added
lines in `assign_key_data()`.
