### PR TITLE
Support loading certificates from current user and local machine

### DIFF
--- a/cng_provider/store/cng_store_functions.h
+++ b/cng_provider/store/cng_store_functions.h
@@ -55,4 +55,7 @@ typedef struct cng_store_ctx {
     char *propquery;
 
     const char * windows_system_store_name;
+
+    /* e.g.CERT_SYSTEM_STORE_CURRENT_USER or CERT_SYSTEM_STORE_LOCAL_MACHINE */ 
+    DWORD store_location_flag; 
 } T_CNG_STORE_CTX;


### PR DESCRIPTION
Enable the use of stores from either the current user or the local machine, based on the URI (e.g., cng://MY@currentuser or cng://ROOT@localmachine). By default, i.e. no store location is given, current user will still be used to be compatible with the current behavior